### PR TITLE
Make find_package() call optional to allow for boost submodule installations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ target_include_directories(
 
 target_compile_features(async_mqtt5 INTERFACE cxx_std_17)
 
-find_package(Boost 1.82 REQUIRED)
+if (NOT ASYNC_MQTT5_SKIP_FIND_PACKAGE)
+    find_package(Boost 1.82 REQUIRED)
+endif()
 target_link_libraries(async_mqtt5
     INTERFACE
     Boost::headers


### PR DESCRIPTION
Thanks for the great library,
we need boost to be a submodule of our repository so that we don't use different boost versions provided by the different distributions. We pinned the boost version by converting it to a submodule.

Problem with async-mqtt5 is it tries to find it system-wide and we dont even install boost anywhere, so find_package() doesnt work.

async-mqtt5 also is just a submodule in our repository.

My change makes it possible to manually disable the find_package call so it doesnt fail or doesnt use incorrect boost versions.